### PR TITLE
Fix bug in path for input/output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ To run the app with on a specific dataset:
 ./run-dev.sh build/bin/fastpl -d $dataset_path -o $output_path
 ```
 
+In that command, both arguments are paths to files, relative to the `data_dir` specified in `app-config.yml`.
+For example, with the `app-config.yml` from the repository,
+the following command generates the `data/output/model1.xml` file: `mkdir -p data/outputs; ./run-dev.sh build/bin/fastpl -d tests/in1dataset.xml -o outputs/model1.xml`.
+
 At the end of the algorithm, the model will be stored in the `$output_path`
 
 ### Logs

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -132,13 +132,13 @@ int App::run() {
     return 1;
   }
 
-  AlternativesPerformance dataset = dg.loadDataset(data_path);
+  AlternativesPerformance dataset = dg.loadDataset(conf.dataset);
   conf.logger->info("Dataset loaded");
 
   HeuristicPipeline hp = HeuristicPipeline(conf, dataset);
   MRSortModel opti = hp.start();
   conf.logger->info("Saving models...");
-  dg.saveModel(model_path, opti.lambda, opti.criteria, opti.profiles, true,
+  dg.saveModel(conf.output, opti.lambda, opti.criteria, opti.profiles, true,
                opti.getId());
   conf.logger->info("App terminated");
   return 0;


### PR DESCRIPTION
The `data_path` from the config was prepended twice to the input/output file names. This went unnoticed until #1 because of the `../` in the `data_path`.

I've also clarified the README about the command-line.